### PR TITLE
fix(kb): kb-bootstrap lista schemas y propaga errores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) y el p
 - EN: initial project bootstrap — `AGENTS.md`, architecture docs, standards, REN templates, code skeleton, CI scripts.
 - ES: knowledge base sprint 1 — chunker NZPLSQL, embedder BGE-M3 lazy, Chroma store, SQLite metadata store, indexer y wiring de CLI (`kb-bootstrap`, `kb-refresh`, `kb-refresh-cron`).
 - EN: knowledge base sprint 1 — NZPLSQL chunker, lazy BGE-M3 embedder, Chroma store, SQLite metadata store, indexer and CLI wiring (`kb-bootstrap`, `kb-refresh`, `kb-refresh-cron`).
+
+### Fixed
+- ES: `nz-workbench kb-bootstrap` ahora lista schemas via `nz_list_schemas` y luego procedures por schema (antes devolvía `0/0/0` en silencio porque `nz_list_procedures` requiere `schema` en nz-mcp). Errores de tools se propagan a `IndexReport.errors` en lugar de silenciarse.
+- EN: `nz-workbench kb-bootstrap` now lists schemas via `nz_list_schemas` and then procedures per schema (previously returned `0/0/0` silently because `nz_list_procedures` requires `schema` in nz-mcp). Tool errors now surface in `IndexReport.errors` instead of being swallowed.

--- a/src/nz_workbench/kb/indexer.py
+++ b/src/nz_workbench/kb/indexer.py
@@ -22,6 +22,7 @@ _log = structlog.get_logger(__name__)
 _TOOL_LIST_PROCS: Final[str] = "nz_list_procedures"
 _TOOL_GET_DDL: Final[str] = "nz_get_procedure_ddl"
 _TOOL_ANALYZE_REFS: Final[str] = "nz_analyze_procedure_references"
+_TOOL_LIST_SCHEMAS: Final[str] = "nz_list_schemas"
 _QUAL_DB_SCHEMA_OBJ: Final[int] = 3
 _QUAL_SCHEMA_OBJ: Final[int] = 2
 
@@ -76,16 +77,19 @@ def _extract_text(res: ToolResult, *, keys: tuple[str, ...]) -> str | None:
     return None
 
 
-def _parse_proc_list(database: str, raw: list[dict[str, Any]]) -> list[_ProcInfo]:
+def _parse_proc_list(database: str, schema: str, raw: list[dict[str, Any]]) -> list[_ProcInfo]:
     procs: list[_ProcInfo] = []
     for item in raw:
-        schema = str(
-            item.get("schema") or item.get("proc_schema") or item.get("procedure_schema") or ""
-        ).strip()
         name = str(item.get("name") or item.get("procedure") or item.get("proc_name") or "").strip()
-        if not schema or not name:
+        if not name:
             continue
-        signature = str(item.get("signature") or item.get("args") or item.get("parameters") or "()")
+        signature = str(
+            item.get("arguments")
+            or item.get("signature")
+            or item.get("args")
+            or item.get("parameters")
+            or "()"
+        )
         last_altered = str(
             item.get("last_altered") or item.get("lastaltertime") or item.get("lastAlterTime") or ""
         )
@@ -102,6 +106,115 @@ def _parse_proc_list(database: str, raw: list[dict[str, Any]]) -> list[_ProcInfo
             )
         )
     return procs
+
+
+def _list_schema_names(client: NzMcpClient, database: str) -> tuple[list[str], str | None]:
+    schemas_res = _call_with_fallbacks(
+        client,
+        _TOOL_LIST_SCHEMAS,
+        [{"database": database}, {"db": database}],
+    )
+    if not _tool_ok(schemas_res):
+        return [], f"failed to list schemas for {database}: {schemas_res.error_code}"
+
+    schema_items = _extract_list(schemas_res, key="schemas")
+    if not schema_items and schemas_res.result is not None:
+        maybe = schemas_res.result.get("items") or schemas_res.result.get("schemas")
+        if isinstance(maybe, list):
+            schema_items = [x for x in maybe if isinstance(x, dict)]
+
+    schema_names = [
+        str(s.get("name") or s.get("schema") or s.get("schema_name") or "").strip()
+        for s in schema_items
+    ]
+    schema_names = [s for s in schema_names if s]
+    if not schema_names:
+        return [], f"list schemas returned empty for {database}"
+    return schema_names, None
+
+
+def _list_procedures_in_schema(
+    client: NzMcpClient, database: str, schema: str
+) -> tuple[list[_ProcInfo], str | None]:
+    procs_res = _call_with_fallbacks(
+        client,
+        _TOOL_LIST_PROCS,
+        [
+            {"database": database, "schema": schema},
+            {"database": database, "schema": schema, "pattern": None},
+            {"db": database, "schema": schema},
+        ],
+    )
+    if not _tool_ok(procs_res):
+        return [], f"failed to list procedures for {database}.{schema}: {procs_res.error_code}"
+
+    raw = _extract_list(procs_res, key="procedures")
+    if not raw and procs_res.result is not None:
+        maybe = procs_res.result.get("items") or procs_res.result.get("procedures")
+        if isinstance(maybe, list):
+            raw = [x for x in maybe if isinstance(x, dict)]
+
+    return _parse_proc_list(database, schema, raw), None
+
+
+def _index_procedures(
+    *,
+    procs: list[_ProcInfo],
+    client: NzMcpClient,
+    chroma: ChromaStore,
+    metadata: MetadataStore,
+    embedder: Embedder,
+) -> tuple[int, int, int, list[str]]:
+    indexed = 0
+    skipped = 0
+    chunks_written = 0
+    errors: list[str] = []
+
+    for proc in procs:
+        key = ProcedureKey(
+            database=proc.database,
+            schema=proc.schema,
+            name=proc.name,
+            signature=proc.signature,
+        )
+        if proc.last_altered:
+            prev_last = metadata.get_last_altered(key)
+            if prev_last is not None and prev_last == proc.last_altered:
+                skipped += 1
+                continue
+
+        _log.info(
+            "kb_index_proc_start",
+            database=proc.database,
+            schema=proc.schema,
+            procedure=proc.name,
+        )
+        did_index, chunks, err = _index_one(
+            client=client,
+            chroma=chroma,
+            metadata=metadata,
+            embedder=embedder,
+            proc=proc,
+        )
+        if err is not None:
+            errors.append(err)
+            _log.error("kb_index_proc_failed", error=err)
+            continue
+        if did_index == 0:
+            skipped += 1
+        else:
+            indexed += 1
+            chunks_written += chunks
+        _log.info(
+            "kb_index_proc_done",
+            database=proc.database,
+            schema=proc.schema,
+            procedure=proc.name,
+            chunks=chunks,
+            indexed=bool(did_index),
+        )
+
+    return indexed, skipped, chunks_written, errors
 
 
 def _call_with_fallbacks(
@@ -319,69 +432,42 @@ def bootstrap(databases: list[str], top_n: int | None = None) -> IndexReport:
     try:
         client.start()
         for db in databases:
-            list_res = _call_with_fallbacks(
-                client,
-                _TOOL_LIST_PROCS,
-                [{"database": db}, {"db": db}],
-            )
-            raw = _extract_list(list_res, key="procedures")
-            if not raw and _tool_ok(list_res) and list_res.result is not None:
-                maybe = list_res.result.get("items") or list_res.result.get("procedures")
-                if isinstance(maybe, list):
-                    raw = [x for x in maybe if isinstance(x, dict)]
+            schemas, err = _list_schema_names(client, db)
+            if err is not None:
+                errors.append(err)
+                continue
 
-            procs = _parse_proc_list(db, raw)
-            if top_n is not None and top_n > 0:
-                procs.sort(key=lambda p: p.size_bytes or 0, reverse=True)
-                procs = procs[:top_n]
+            for schema_name in schemas:
+                procs, proc_err = _list_procedures_in_schema(client, db, schema_name)
+                if proc_err is not None:
+                    errors.append(proc_err)
+                    continue
 
-            for proc in procs:
-                key = ProcedureKey(
-                    database=proc.database,
-                    schema=proc.schema,
-                    name=proc.name,
-                    signature=proc.signature,
-                )
-                if proc.last_altered:
-                    prev_last = metadata.get_last_altered(key)
-                    if prev_last is not None and prev_last == proc.last_altered:
-                        procedures_skipped += 1
-                        continue
+                if top_n is not None and top_n > 0:
+                    procs.sort(key=lambda p: p.size_bytes or 0, reverse=True)
+                    procs = procs[:top_n]
 
-                _log.info(
-                    "kb_index_proc_start",
-                    database=proc.database,
-                    schema=proc.schema,
-                    procedure=proc.name,
-                )
-                indexed, chunks, err = _index_one(
+                newly_indexed, newly_skipped, newly_chunks, proc_errors = _index_procedures(
+                    procs=procs,
                     client=client,
                     chroma=chroma,
                     metadata=metadata,
                     embedder=embedder,
-                    proc=proc,
                 )
-                if err is not None:
-                    errors.append(err)
-                    _log.error("kb_index_proc_failed", error=err)
-                    continue
-                if indexed == 0:
-                    procedures_skipped += 1
-                else:
-                    procedures_indexed += 1
-                    chunks_written += chunks
-                _log.info(
-                    "kb_index_proc_done",
-                    database=proc.database,
-                    schema=proc.schema,
-                    procedure=proc.name,
-                    chunks=chunks,
-                    indexed=bool(indexed),
-                )
+                procedures_indexed += newly_indexed
+                procedures_skipped += newly_skipped
+                chunks_written += newly_chunks
+                errors.extend(proc_errors)
     finally:
         client.stop()
 
     duration = time.perf_counter() - t0
+    if procedures_indexed == 0 and procedures_skipped == 0 and not errors:
+        errors.append(
+            "no procedures were discovered in any database. Verify that nz_list_schemas + "
+            "nz_list_procedures are available and that the profile has visibility over the "
+            "requested databases."
+        )
     return IndexReport(
         procedures_indexed=procedures_indexed,
         procedures_skipped=procedures_skipped,

--- a/tests/unit/test_kb_indexer.py
+++ b/tests/unit/test_kb_indexer.py
@@ -83,15 +83,28 @@ class _FakeNzMcpClient:
         return
 
     def call(self, tool: str, arguments: dict[str, Any]) -> ToolResult:
+        if tool == "nz_list_schemas":
+            return ToolResult(
+                ok=True,
+                result={"schemas": [{"name": "DBO"}]},
+                error_code=None,
+                error_context=None,
+            )
         if tool == "nz_list_procedures":
+            if "schema" not in arguments:
+                return ToolResult(
+                    ok=False,
+                    result=None,
+                    error_code="INVALID_INPUT",
+                    error_context={"detail": "schema required"},
+                )
             return ToolResult(
                 ok=True,
                 result={
                     "procedures": [
                         {
-                            "schema": "DBO",
                             "name": "SP1",
-                            "signature": "()",
+                            "arguments": "()",
                             "last_altered": "2026-01-01T00:00:00Z",
                             "size_bytes": 10,
                         }

--- a/tests/unit/test_kb_indexer_issue3_regression.py
+++ b/tests/unit/test_kb_indexer_issue3_regression.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from nz_workbench.kb import indexer
+from nz_workbench.nz_mcp_client import ToolResult
+
+
+class _FailSchemasClient:
+    def __init__(self, bin_path: str) -> None:
+        assert bin_path
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        return
+
+    def call(self, tool: str, arguments: dict[str, Any]) -> ToolResult:
+        if tool == "nz_list_schemas":
+            return ToolResult(
+                ok=False,
+                result=None,
+                error_code="INVALID_INPUT",
+                error_context={"tool": tool, "arguments": arguments},
+            )
+        return ToolResult(ok=False, result=None, error_code="UNEXPECTED", error_context=None)
+
+
+@pytest.mark.unit
+def test_bootstrap_propagates_schema_list_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cfg = type(
+        "Cfg",
+        (),
+        {"state_dir": tmp_path, "nz_mcp_bin": "nz-mcp", "embedder_model": "BAAI/bge-m3"},
+    )()
+    monkeypatch.setattr(indexer, "load_config", lambda: cfg)
+    monkeypatch.setattr(indexer, "NzMcpClient", _FailSchemasClient)
+
+    report = indexer.bootstrap(["PROD_X"])
+    assert report.errors
+    assert any("failed to list schemas" in e for e in report.errors)
+
+
+@pytest.mark.unit
+def test_parse_proc_list_accepts_items_without_schema() -> None:
+    raw = [{"name": "SP1", "arguments": "(DATE)"}, {"name": "SP2", "arguments": "()"}]
+    procs = indexer._parse_proc_list("PROD_X", "DBO", raw)
+    assert [p.schema for p in procs] == ["DBO", "DBO"]


### PR DESCRIPTION
## ¿Qué cambia?

Corrige regresión del KB bootstrap donde `kb-bootstrap` reporta 0/0/0 silenciosamente.

- `kb.indexer.bootstrap()` ahora lista schemas por database via `nz_list_schemas` y luego lista procedures por schema via `nz_list_procedures` (que requiere `schema`).
- `_parse_proc_list()` ya no exige que cada item traiga `schema` (el schema se inyecta desde el caller) y prioriza `arguments` para la firma.
- Los errores de tools dejan de ser silenciosos y aparecen en `IndexReport.errors`.

## Issue relacionado

Closes #3

## Acción según AGENTS.md

- **Ruta (keywords)**: `kb/indexer.py`
- **Docs leídos**:
  - `AGENTS.md`
  - `docs/architecture/knowledge-base.md`
- **Rol asumido**: Backend

## Auditoría pre-merge

- [x] 1. Contract and compatibility — no rompe firmas públicas; mejora reporte de errores.
- [x] 2. Security — sigue usando solo `nz-mcp` como ruta a Netezza.
- [x] 3. Maintainability — refactor a helpers para mantener límites de ruff.
- [x] 4. Tests — agrega regresiones para schemas + propagación de errores.
- [x] 5. Typing and style — `ruff` y `mypy --strict` limpios.
- [x] 6. Documentation — no aplica.
- [x] 7. Language and form — branch/título/commits conventional; PR body con 5 headings.
- [x] Zero-guess — no se silencian errores de tools.

## Validación humana

- [ ] Sí — explicar por qué:
- [x] No — cambio mecánico / cubierto por tests.