### PR TITLE
fix(nz-mcp-client): unwrap MCP tools/call envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,7 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) y el p
 - EN: knowledge base sprint 1 — NZPLSQL chunker, lazy BGE-M3 embedder, Chroma store, SQLite metadata store, indexer and CLI wiring (`kb-bootstrap`, `kb-refresh`, `kb-refresh-cron`).
 
 ### Fixed
+- ES: `NzMcpClient.call()` ahora desenvuelve el envelope MCP de `tools/call` (lee `structuredContent.result`) y mapea errores estructurados; incluye fallback a JSON en bloques `content`.
+- EN: `NzMcpClient.call()` now unwraps the MCP `tools/call` envelope (reads `structuredContent.result`) and maps structured errors; includes fallback to JSON in `content` blocks.
 - ES: `nz-workbench kb-bootstrap` ahora lista schemas via `nz_list_schemas` y luego procedures por schema (antes devolvía `0/0/0` en silencio porque `nz_list_procedures` requiere `schema` en nz-mcp). Errores de tools se propagan a `IndexReport.errors` en lugar de silenciarse.
 - EN: `nz-workbench kb-bootstrap` now lists schemas via `nz_list_schemas` and then procedures per schema (previously returned `0/0/0` silently because `nz_list_procedures` requires `schema` in nz-mcp). Tool errors now surface in `IndexReport.errors` instead of being swallowed.

--- a/src/nz_workbench/nz_mcp_client/client.py
+++ b/src/nz_workbench/nz_mcp_client/client.py
@@ -36,6 +36,81 @@ class ToolResult:
     error_context: dict[str, Any] | None
 
 
+def _tool_error(code: str | None, context: Any) -> ToolResult:
+    ctx = context if isinstance(context, dict) else None
+    return ToolResult(
+        ok=False,
+        result=None,
+        error_code=str(code) if code is not None else None,
+        error_context=ctx,
+    )
+
+
+def _parse_text_content_json(content: Any) -> dict[str, Any] | None:
+    if not isinstance(content, list):
+        return None
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "text":
+            continue
+        text = block.get("text")
+        if not isinstance(text, str) or not text.strip():
+            continue
+        try:
+            parsed = json.loads(text)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def _unwrap_tool_payload(tool_payload: dict[str, Any], *, is_error: bool) -> ToolResult:
+    if isinstance(tool_payload.get("error"), dict):
+        err_obj = tool_payload["error"]
+        return _tool_error(err_obj.get("code") or "TOOL_ERROR", err_obj.get("context"))
+
+    if isinstance(tool_payload.get("result"), dict):
+        return ToolResult(
+            ok=True, result=tool_payload["result"], error_code=None, error_context=None
+        )
+
+    if is_error:
+        return _tool_error("TOOL_ERROR", None)
+
+    return ToolResult(ok=True, result=tool_payload, error_code=None, error_context=None)
+
+
+def _unwrap_tool_call_envelope(envelope: dict[str, Any]) -> ToolResult:
+    looks_like_mcp_envelope = any(
+        key in envelope for key in ("content", "structuredContent", "isError")
+    )
+    if not looks_like_mcp_envelope:
+        return _unwrap_tool_payload(envelope, is_error=False)
+
+    # MCP tools/call wraps tool output in:
+    # {"content": [...], "structuredContent": {...}, "isError": bool}
+    is_error = bool(envelope.get("isError"))
+    structured = envelope.get("structuredContent")
+
+    tool_payload: dict[str, Any] | None = None
+    if isinstance(structured, dict):
+        if isinstance(structured.get("result"), dict):
+            tool_payload = structured["result"]
+        elif isinstance(structured.get("error"), dict):
+            tool_payload = {"error": structured["error"]}
+        else:
+            tool_payload = structured
+    else:
+        tool_payload = _parse_text_content_json(envelope.get("content"))
+
+    if tool_payload is None:
+        tool_payload = {}
+
+    return _unwrap_tool_payload(tool_payload, is_error=is_error)
+
+
 class NzMcpClient:
     """Connects to ``nz-mcp serve`` as a subprocess via stdio JSON-RPC."""
 
@@ -123,13 +198,11 @@ class NzMcpClient:
                 error_context=data,
             )
 
-        result = payload.get("result")
-        # We expect tool implementations to return a JSON object.
-        if isinstance(result, dict):
-            return ToolResult(ok=True, result=result, error_code=None, error_context=None)
-        if result is None:
+        envelope = payload.get("result")
+        if not isinstance(envelope, dict):
             return ToolResult(ok=True, result={}, error_code=None, error_context=None)
-        return ToolResult(ok=True, result={"result": result}, error_code=None, error_context=None)
+
+        return _unwrap_tool_call_envelope(envelope)
 
     # ----- JSON-RPC helpers -----
     def _stdin(self) -> IO[str]:

--- a/tests/unit/test_nz_mcp_client.py
+++ b/tests/unit/test_nz_mcp_client.py
@@ -38,7 +38,17 @@ def test_nz_mcp_client_initialize_and_call(monkeypatch: pytest.MonkeyPatch) -> N
         json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"name": "nz-mcp"}}}),
         "not-json-noise",
         json.dumps({"jsonrpc": "2.0", "method": "notifications/logging", "params": {"msg": "x"}}),
-        json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"ok": True, "value": 1}}),
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {
+                    "content": [{"type": "text", "text": "ok"}],
+                    "structuredContent": {"result": {"ok": True, "value": 1}},
+                    "isError": False,
+                },
+            }
+        ),
         json.dumps({"jsonrpc": "2.0", "id": 3, "result": {}}),
     ]
     fake = _FakeProc(stdin=io.StringIO(), stdout=io.StringIO("\n".join(out_lines) + "\n"))
@@ -130,7 +140,13 @@ def test_nz_mcp_client_start_raises_on_initialize_error(
 def test_nz_mcp_client_wraps_non_dict_results(monkeypatch: pytest.MonkeyPatch) -> None:
     out_lines = [
         json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}),
-        json.dumps({"jsonrpc": "2.0", "id": 2, "result": None}),
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {"content": [], "structuredContent": {}, "isError": False},
+            }
+        ),
         json.dumps({"jsonrpc": "2.0", "id": 3, "result": {}}),
     ]
     fake = _FakeProc(stdin=io.StringIO(), stdout=io.StringIO("\n".join(out_lines) + "\n"))
@@ -140,6 +156,116 @@ def test_nz_mcp_client_wraps_non_dict_results(monkeypatch: pytest.MonkeyPatch) -
     res = client.call("nz_list_procedures", {"database": "PROD_X"})
     assert res.ok is True
     assert res.result == {}
+
+
+@pytest.mark.unit
+def test_call_extracts_structured_content_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    out_lines = [
+        json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}),
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {
+                    "content": [{"type": "text", "text": "err"}],
+                    "structuredContent": {
+                        "error": {"code": "INVALID_INPUT", "context": {"detail": "schema required"}}
+                    },
+                    "isError": True,
+                },
+            }
+        ),
+        json.dumps({"jsonrpc": "2.0", "id": 3, "result": {}}),
+    ]
+    fake = _FakeProc(stdin=io.StringIO(), stdout=io.StringIO("\n".join(out_lines) + "\n"))
+    monkeypatch.setattr("subprocess.Popen", lambda *_a, **_k: fake)
+    client = NzMcpClient(bin_path="nz-mcp")
+    client.start()
+    res = client.call("nz_list_procedures", {"database": "PROD_X"})
+    assert res.ok is False
+    assert res.error_code == "INVALID_INPUT"
+    assert res.error_context == {"detail": "schema required"}
+
+
+@pytest.mark.unit
+def test_call_is_error_flag_without_structured_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    out_lines = [
+        json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}),
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {
+                    "content": [{"type": "text", "text": "no structured"}],
+                    "isError": True,
+                },
+            }
+        ),
+        json.dumps({"jsonrpc": "2.0", "id": 3, "result": {}}),
+    ]
+    fake = _FakeProc(stdin=io.StringIO(), stdout=io.StringIO("\n".join(out_lines) + "\n"))
+    monkeypatch.setattr("subprocess.Popen", lambda *_a, **_k: fake)
+    client = NzMcpClient(bin_path="nz-mcp")
+    client.start()
+    res = client.call("nz_list_procedures", {"database": "PROD_X"})
+    assert res.ok is False
+    assert res.error_code == "TOOL_ERROR"
+
+
+@pytest.mark.unit
+def test_call_fallback_parses_text_content_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    out_lines = [
+        json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}),
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps({"result": {"schemas": [{"name": "DBO"}]}}),
+                        }
+                    ],
+                    "isError": False,
+                },
+            }
+        ),
+        json.dumps({"jsonrpc": "2.0", "id": 3, "result": {}}),
+    ]
+    fake = _FakeProc(stdin=io.StringIO(), stdout=io.StringIO("\n".join(out_lines) + "\n"))
+    monkeypatch.setattr("subprocess.Popen", lambda *_a, **_k: fake)
+    client = NzMcpClient(bin_path="nz-mcp")
+    client.start()
+    res = client.call("nz_list_schemas", {"database": "PROD_X"})
+    assert res.ok is True
+    assert res.result == {"schemas": [{"name": "DBO"}]}
+
+
+@pytest.mark.unit
+def test_call_unknown_shape_returns_inner_as_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    out_lines = [
+        json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}),
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {
+                    "content": [],
+                    "structuredContent": {"hello": "world"},
+                    "isError": False,
+                },
+            }
+        ),
+        json.dumps({"jsonrpc": "2.0", "id": 3, "result": {}}),
+    ]
+    fake = _FakeProc(stdin=io.StringIO(), stdout=io.StringIO("\n".join(out_lines) + "\n"))
+    monkeypatch.setattr("subprocess.Popen", lambda *_a, **_k: fake)
+    client = NzMcpClient(bin_path="nz-mcp")
+    client.start()
+    res = client.call("nz_any", {})
+    assert res.ok is True
+    assert res.result == {"hello": "world"}
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## ¿Qué cambia?

`NzMcpClient.call()` ahora desenvuelve el envelope de MCP para `tools/call` y devuelve el payload real del tool (principalmente desde `structuredContent.result`). Esto arregla los casos donde `kb-bootstrap` recibía envelopes MCP y no encontraba claves como `schemas` / `procedures` en el resultado, devolviendo `0/0/0` con errores silenciosos.

El fix incluye:

- Extracción prioritaria de `structuredContent` (la fuente canónica del MCP SDK).
- Fallback a parsear JSON desde `content[0].text` si `structuredContent` no está presente.
- Manejo explícito del flag `isError` y del shape `{error: {...}}` interno de nz-mcp.
- Compatibilidad retro con tools legacy que no usan envelope (tests existentes siguen verdes).

## Issue relacionado

Closes #5

## Acción según AGENTS.md

- **Ruta (keywords)**: `src/nz_workbench/nz_mcp_client/client.py`, MCP envelope, `tools/call`, `structuredContent`
- **Docs leídos**:
  - `AGENTS.md`
  - `docs/standards/pr-audit.md`
  - `docs/standards/testing.md`
- **Rol asumido**: Backend

## Auditoría pre-merge

- [x] 1. Contract and compatibility — `CHANGELOG.md` actualizado con entrada bilingüe en `Fixed`.
- [x] 2. Security — sin credenciales, sin SQL directo a Netezza, sin `except Exception` sin re-raise.
- [x] 3. Maintainability — una intención por PR; parsing aislado en el cliente.
- [x] 4. Tests — nuevos, verdes locales, coverage global mantenida.
- [x] 5. Typing and style — `ruff` y `mypy --strict` limpios.
- [x] 6. Documentation — `CHANGELOG.md` actualizado.
- [x] 7. Language and form — título/branch/commits conventional, PR body con los 5 headings.
- [x] Zero-guess — sin asunciones silenciosas; el cliente soporta shape MCP real + fallback texto + shape legacy.

## Validación humana

- [ ] Sí — explicar por qué:
- [x] No — cambio mecánico del cliente MCP cubierto por tests unitarios; validación end-to-end contra nz-mcp real pendiente como siguiente paso manual.
