### PR TITLE
fix(cli): silencia structlog durante la barra de progreso (issue 9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) y el p
 - EN: Rich progress bar on `kb-bootstrap` / `kb-refresh` / `kb-refresh-cron` showing per-procedure description, M/N counter, elapsed time, and ETA; INFO logs are silenced while the bar is active to keep the render clean. The indexer exposes a UI-agnostic `on_progress` callback (`ProgressCallback`/`ProgressEvent`).
 
 ### Fixed
+- ES: `_progress_context` ahora silencia también los eventos INFO de structlog mediante un procesador controlado por `set_suppress_info_events`. Antes solo bajaba el root logger, que no afectaba a structlog por usar `PrintLoggerFactory` directo — los eventos `kb_index_proc_start/done` seguían rompiendo la animación de la barra Rich.
+- EN: `_progress_context` now silences structlog INFO events too via a processor driven by `set_suppress_info_events`. Previously only the root stdlib logger was lowered, which had no effect on structlog (goes through `PrintLoggerFactory` directly) — events like `kb_index_proc_start/done` kept shredding the Rich bar animation.
+
+### Fixed
 - ES: `NzMcpClient.call()` ahora desenvuelve el envelope MCP de `tools/call` (lee `structuredContent.result`) y mapea errores estructurados; incluye fallback a JSON en bloques `content`.
 - EN: `NzMcpClient.call()` now unwraps the MCP `tools/call` envelope (reads `structuredContent.result`) and maps structured errors; includes fallback to JSON in `content` blocks.
 - ES: `nz-workbench kb-bootstrap` ahora lista schemas via `nz_list_schemas` y luego procedures por schema (antes devolvía `0/0/0` en silencio porque `nz_list_procedures` requiere `schema` en nz-mcp). Errores de tools se propagan a `IndexReport.errors` en lugar de silenciarse.

--- a/src/nz_workbench/cli.py
+++ b/src/nz_workbench/cli.py
@@ -22,7 +22,7 @@ from rich.table import Table
 
 from nz_workbench import __version__
 from nz_workbench.kb import indexer as kb_indexer
-from nz_workbench.logging_config import configure_logging_for_stdio
+from nz_workbench.logging_config import configure_logging_for_stdio, set_suppress_info_events
 from nz_workbench.mcp_server import run_stdio_server
 
 app = typer.Typer(
@@ -58,6 +58,7 @@ def _progress_context() -> Iterator[kb_indexer.ProgressCallback]:
     root_logger = logging.getLogger()
     previous_level = root_logger.level
     root_logger.setLevel(logging.WARNING)
+    set_suppress_info_events(True)
 
     console = Console(stderr=True)
     progress = Progress(
@@ -93,6 +94,7 @@ def _progress_context() -> Iterator[kb_indexer.ProgressCallback]:
         yield _on_progress
     finally:
         progress.stop()
+        set_suppress_info_events(False)
         root_logger.setLevel(previous_level)
 
 

--- a/src/nz_workbench/logging_config.py
+++ b/src/nz_workbench/logging_config.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import Final
+from collections.abc import MutableMapping
+from typing import Any, Final
 
 import structlog
 
@@ -19,6 +20,35 @@ _NOISY_LOGGERS: Final[tuple[str, ...]] = (
     "torch",
     "urllib3",
 )
+
+
+class _SuppressState:
+    """Mutable switch read by the structlog processor on every call.
+
+    Toggled by long-running CLI UI (e.g. the kb-bootstrap Rich progress bar)
+    to drop INFO/DEBUG structlog events that would shred the in-place render.
+    A processor-based filter works regardless of logger caching, unlike
+    ``structlog.configure(wrapper_class=...)`` which only affects loggers
+    created *after* the reconfigure.
+    """
+
+    suppress: bool = False
+
+
+def set_suppress_info_events(active: bool) -> None:
+    """Toggle INFO/DEBUG silencing for structlog output."""
+
+    _SuppressState.suppress = active
+
+
+def _drop_info_when_suppressed(
+    _logger: Any,
+    _method_name: str,
+    event_dict: MutableMapping[str, Any],
+) -> MutableMapping[str, Any]:
+    if _SuppressState.suppress and event_dict.get("level") in {"debug", "info"}:
+        raise structlog.DropEvent
+    return event_dict
 
 
 def configure_logging_for_stdio(level: int = logging.INFO) -> None:
@@ -36,6 +66,7 @@ def configure_logging_for_stdio(level: int = logging.INFO) -> None:
     structlog.configure(
         processors=[
             structlog.processors.add_log_level,
+            _drop_info_when_suppressed,
             structlog.processors.TimeStamper(fmt="iso", utc=True),
             structlog.processors.StackInfoRenderer(),
             structlog.processors.format_exc_info,
@@ -51,4 +82,4 @@ def configure_logging_for_stdio(level: int = logging.INFO) -> None:
     )
 
 
-__all__ = ["configure_logging_for_stdio"]
+__all__ = ["configure_logging_for_stdio", "set_suppress_info_events"]

--- a/tests/unit/test_logging_and_errors.py
+++ b/tests/unit/test_logging_and_errors.py
@@ -1,15 +1,49 @@
 from __future__ import annotations
 
+import io
+import logging
+
 import pytest
+import structlog
 
 from nz_workbench.errors import AmbiguityError, NzMcpUnavailableError
-from nz_workbench.logging_config import configure_logging_for_stdio
+from nz_workbench.logging_config import configure_logging_for_stdio, set_suppress_info_events
 from nz_workbench.mcp_server import run_stdio_server
 
 
 @pytest.mark.unit
 def test_configure_logging_for_stdio_does_not_crash() -> None:
     configure_logging_for_stdio()
+
+
+@pytest.mark.unit
+def test_suppress_info_events_drops_structlog_info_while_active(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When suppression is on, ``log.info`` emits nothing; errors still flow."""
+
+    configure_logging_for_stdio(level=logging.INFO)
+    buffer = io.StringIO()
+    log = structlog.wrap_logger(structlog.PrintLogger(file=buffer))
+
+    set_suppress_info_events(True)
+    try:
+        log.info("noisy_event", payload="x")
+        log.warning("still_visible")
+    finally:
+        set_suppress_info_events(False)
+
+    # Capture stderr too, since PrintLogger defaults may target it elsewhere.
+    captured = buffer.getvalue() + capsys.readouterr().err
+    assert "noisy_event" not in captured, captured
+    assert "still_visible" in captured, captured
+
+    # After toggling off: INFO is visible again.
+    buffer.seek(0)
+    buffer.truncate()
+    log.info("back_online")
+    post = buffer.getvalue() + capsys.readouterr().err
+    assert "back_online" in post, post
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## ¿Qué cambia?

``_progress_context`` ahora silencia los eventos INFO de structlog mediante un procesador controlado por ``set_suppress_info_events``. Antes solo bajaba el root stdlib a WARNING, que no afectaba a structlog porque usa ``PrintLoggerFactory`` directo a ``sys.stderr``. Los eventos del indexer (``nz_mcp_started``, ``kb_index_proc_start/done``) rompían la animación de la barra Rich.

La alternativa obvia — ``structlog.configure(wrapper_class=filtering_bound_logger(WARNING))`` dentro del context — no funciona porque los loggers cacheados a nivel módulo (p.ej. ``_log = structlog.get_logger(__name__)`` en el indexer) retienen el wrapper con el que se crearon. Un procesador que lee un flag mutable es resiliente al caching.

## Issue relacionado

Closes #9

## Acción según AGENTS.md

- **Ruta (keywords)**: cli, rich progress bar, structlog, stderr
- **Docs leídos**: ``AGENTS.md``, ``docs/standards/testing.md``, ``CHANGELOG.md``
- **Rol asumido**: Backend (autor IA) + Tech Lead

## Auditoría pre-merge

- [x] 1. Contract and compatibility — entrada bilingüe en ``CHANGELOG.md`` → ``Fixed``; API nueva ``set_suppress_info_events`` exportada explícitamente.
- [x] 2. Security — sin SQL, sin credenciales; solo toggle de nivel de log.
- [x] 3. Maintainability — ``_SuppressState`` encapsula el flag; procesador < 10 LoC; una intención por PR.
- [x] 4. Tests — nuevo test verifica que INFO se dropea durante suppress-on y vuelve en suppress-off; ``pytest -q`` → 77/77 local, coverage 87.42%.
- [x] 5. Typing and style — ``ruff`` + ``mypy --strict`` limpios. Firma del procesador tipada con ``MutableMapping[str, Any]`` para cuadrar con structlog.
- [x] 6. Documentation — docstrings en ``_SuppressState`` y ``_drop_info_when_suppressed`` explican por qué no se reconfigura ``wrapper_class``.
- [x] 7. Language and form — título conventional, branch ``fix/9-...``, commit y body en español; código/comentarios en inglés.
- [x] Zero-guess — el mapeo de levels está explícito (``{"debug", "info"}``); WARNING/ERROR/CRITICAL siempre pasan.

## Validación humana

- [x] Sí — explicar por qué: **continuación de la excepción al patrón dual-IA** iniciada en #7. El usuario autorizó seguir con el cycle end-to-end por Claude para cerrar la UX. Validación humana = correr kb-bootstrap tras el merge (combinado con el fix gemelo en nz-mcp) y confirmar la barra animándose sin texto intercalado.