### PR TITLE
fix(kb): ceiling duro por chunk y auto reindex por version del chunker (issue 11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) y el p
 ### Fixed
 - ES: `_progress_context` ahora silencia también los eventos INFO de structlog mediante un procesador controlado por `set_suppress_info_events`. Antes solo bajaba el root logger, que no afectaba a structlog por usar `PrintLoggerFactory` directo — los eventos `kb_index_proc_start/done` seguían rompiendo la animación de la barra Rich.
 - EN: `_progress_context` now silences structlog INFO events too via a processor driven by `set_suppress_info_events`. Previously only the root stdlib logger was lowered, which had no effect on structlog (goes through `PrintLoggerFactory` directly) — events like `kb_index_proc_start/done` kept shredding the Rich bar animation.
+- ES: `chunker.chunk` garantiza que todos los chunks tienen ≤ `MAX_TOKENS` (2000) mediante un corte duro post-stitch. Antes, procedures con bloques monolíticos sin semicolons top-level podían generar chunks > 8192 tokens, que BGE-M3 truncaba silenciosamente y dejaba la cola de la SP sin representación en el embedding (recall cero para búsquedas en esa zona).
+- EN: `chunker.chunk` now guarantees every chunk is ≤ `MAX_TOKENS` (2000) via a post-stitch hard ceiling. Before, procedures with monolithic blocks and no top-level semicolons could yield chunks > 8192 tokens, which BGE-M3 silently truncates — tail content had zero embedding representation and was invisible to semantic search.
+
+### Added
+- ES: `CHUNKER_VERSION` persistido en `procedure.chunker_version` (migración automática para DBs legacy). El indexer re-chunka/re-embedda cuando la versión almacenada no coincide con la actual, aunque `body_sha256` sea el mismo. Así un bump del chunker dispara re-index sin requerir `--force` manual.
+- EN: `CHUNKER_VERSION` persisted in `procedure.chunker_version` (auto-migrates legacy DBs). The indexer re-chunks/re-embeds when the stored version doesn't match the current one, even if `body_sha256` is unchanged — a chunker bump triggers re-index without requiring manual `--force`.
 
 ### Fixed
 - ES: `NzMcpClient.call()` ahora desenvuelve el envelope MCP de `tools/call` (lee `structuredContent.result`) y mapea errores estructurados; incluye fallback a JSON en bloques `content`.

--- a/src/nz_workbench/kb/chunker.py
+++ b/src/nz_workbench/kb/chunker.py
@@ -16,6 +16,15 @@ from typing import Any, Final, cast
 
 TARGET_TOKENS: Final[int] = 400
 OVERLAP_TOKENS: Final[int] = 50
+# Hard ceiling per chunk. BGE-M3 truncates above 8192 tokens silently, which
+# means any logic past that cut never makes it into the embedding — zero recall
+# on queries matching that zone. We pick 2000 to leave headroom while keeping
+# blocks large enough to preserve semantic context.
+MAX_TOKENS: Final[int] = 2000
+
+# Bumped whenever the chunker output can change for the same input. Stored per
+# procedure in the metadata DB; the indexer re-chunks+re-embeds when it drifts.
+CHUNKER_VERSION: Final[int] = 1
 
 _DEFAULT_TOKENIZER_MODEL: Final[str] = "BAAI/bge-m3"
 _ENV_TOKENIZER_MODEL: Final[str] = "NZ_WORKBENCH_TOKENIZER_MODEL"
@@ -474,12 +483,95 @@ def _stitch(segments: list[_Segment], target_tokens: int, overlap_tokens: int) -
     return chunks
 
 
+def _hard_split_text(text: str, max_tokens: int) -> list[str]:
+    """Split text into pieces each tokenizing to ≤ ``max_tokens``.
+
+    Prefers whitespace cuts near the estimated token-ratio target; falls back
+    to character slicing if whitespace boundaries don't converge. Guarantees
+    termination and progress: every iteration consumes ≥ 1 character.
+    """
+
+    if _count_tokens(text) <= max_tokens:
+        return [text]
+
+    pieces: list[str] = []
+    remaining = text
+
+    while _count_tokens(remaining) > max_tokens:
+        total_tokens = _count_tokens(remaining)
+        ratio = len(remaining) / max(1, total_tokens)
+        # Target char index leaving a 10% safety margin below max_tokens.
+        cut = max(1, int(max_tokens * ratio * 0.9))
+        cut = min(cut, len(remaining) - 1)
+
+        # Prefer a whitespace boundary within the second half of the estimate
+        # so we don't shrink chunks dramatically hunting for whitespace.
+        back = cut
+        min_back = max(1, cut // 2)
+        while back > min_back and not remaining[back].isspace():
+            back -= 1
+        if remaining[back : back + 1].isspace():
+            cut = back
+
+        # Guarantee the left half is under the ceiling; shrink if tokenization
+        # came out above estimate.
+        while cut > 1 and _count_tokens(remaining[:cut]) > max_tokens:
+            cut = max(1, int(cut * 0.9))
+
+        if cut <= 0:
+            break
+
+        pieces.append(remaining[:cut])
+        remaining = remaining[cut:]
+
+    if remaining:
+        pieces.append(remaining)
+    return pieces
+
+
+def _enforce_chunk_ceiling(chunks: list[Chunk], max_tokens: int) -> list[Chunk]:
+    """Post-processing guard: split any chunk whose text exceeds ``max_tokens``.
+
+    The upstream logical/semicolon-aware splitter can leave oversized chunks
+    when a single statement has no top-level whitespace breakpoints (rare but
+    real). This safety net guarantees the invariant without requiring the
+    upstream logic to be perfect.
+    """
+
+    out: list[Chunk] = []
+    for ch in chunks:
+        if _count_tokens(ch.text) <= max_tokens:
+            out.append(ch)
+            continue
+        for piece in _hard_split_text(ch.text, max_tokens):
+            out.append(
+                Chunk(
+                    text=piece,
+                    line_from=ch.line_from,
+                    line_to=ch.line_to,
+                    section_hint=ch.section_hint,
+                )
+            )
+    return out
+
+
 def chunk(body: str) -> list[Chunk]:
     """Return the chunks of a procedure body."""
 
     segments = _segment(body)
+    # ``_split_oversized_segments`` caps each segment near ``OVERLAP_TOKENS`` so
+    # the stitch step's overlap loop can back up cleanly in small units; the
+    # hard guarantee against BGE-M3 truncation comes from ``_enforce_chunk_ceiling``.
     segments = _split_oversized_segments(segments, max_tokens=OVERLAP_TOKENS)
-    return _stitch(segments, TARGET_TOKENS, OVERLAP_TOKENS)
+    chunks = _stitch(segments, TARGET_TOKENS, OVERLAP_TOKENS)
+    return _enforce_chunk_ceiling(chunks, MAX_TOKENS)
 
 
-__all__ = ["OVERLAP_TOKENS", "TARGET_TOKENS", "Chunk", "chunk"]
+__all__ = [
+    "CHUNKER_VERSION",
+    "MAX_TOKENS",
+    "OVERLAP_TOKENS",
+    "TARGET_TOKENS",
+    "Chunk",
+    "chunk",
+]

--- a/src/nz_workbench/kb/indexer.py
+++ b/src/nz_workbench/kb/indexer.py
@@ -13,7 +13,7 @@ import structlog
 
 from nz_workbench.config import load_config
 from nz_workbench.kb.chroma_store import ChromaStore
-from nz_workbench.kb.chunker import chunk
+from nz_workbench.kb.chunker import CHUNKER_VERSION, chunk
 from nz_workbench.kb.embedder import Embedder, make_embedder
 from nz_workbench.kb.metadata_store import MetadataStore, ProcedureKey, Reference
 from nz_workbench.nz_mcp_client import NzMcpClient, ToolResult
@@ -431,7 +431,12 @@ def _index_one(
 
     body_hash = _sha256(ddl)
     previous_hash = metadata.get_body_sha256(key)
-    if previous_hash is not None and previous_hash == body_hash:
+    previous_chunker = metadata.get_chunker_version(key)
+    if (
+        previous_hash is not None
+        and previous_hash == body_hash
+        and previous_chunker == CHUNKER_VERSION
+    ):
         return 0, 0, None
 
     # Remove prior chunks to avoid stale chunk IDs when chunk counts shrink.
@@ -475,7 +480,12 @@ def _index_one(
     if not references:
         references = _fallback_regex_references(ddl)
 
-    metadata.upsert_procedure(key, last_altered=proc.last_altered, body_sha256=body_hash)
+    metadata.upsert_procedure(
+        key,
+        last_altered=proc.last_altered,
+        body_sha256=body_hash,
+        chunker_version=CHUNKER_VERSION,
+    )
     metadata.upsert_references(key, references)
 
     return 1, len(chunks), None

--- a/src/nz_workbench/kb/metadata_store.py
+++ b/src/nz_workbench/kb/metadata_store.py
@@ -52,7 +52,7 @@ class MetadataStore:
         return conn
 
     def ensure_schema(self) -> None:
-        """Create tables and indexes if not present."""
+        """Create tables and indexes if not present; apply lightweight migrations."""
 
         with self._connect() as conn:
             conn.executescript(
@@ -65,6 +65,7 @@ class MetadataStore:
                     last_altered   TEXT,
                     body_sha256    TEXT,
                     indexed_at     TEXT NOT NULL,
+                    chunker_version INTEGER NOT NULL DEFAULT 0,
                     PRIMARY KEY (database, schema, name, signature)
                 );
 
@@ -99,8 +100,22 @@ class MetadataStore:
                 );
                 """
             )
+            # Migration: older DBs (bootstrapped before chunker versioning) won't
+            # have chunker_version. Add it with default 0 so every existing row
+            # mismatches any positive CHUNKER_VERSION → forces a clean re-index.
+            cols = {row["name"] for row in conn.execute("PRAGMA table_info(procedure);").fetchall()}
+            if "chunker_version" not in cols:
+                conn.execute(
+                    "ALTER TABLE procedure ADD COLUMN chunker_version INTEGER NOT NULL DEFAULT 0;"
+                )
 
-    def upsert_procedure(self, key: ProcedureKey, last_altered: str, body_sha256: str) -> None:
+    def upsert_procedure(
+        self,
+        key: ProcedureKey,
+        last_altered: str,
+        body_sha256: str,
+        chunker_version: int = 0,
+    ) -> None:
         """Insert or replace a procedure row."""
 
         indexed_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
@@ -109,13 +124,14 @@ class MetadataStore:
                 """
                 INSERT INTO procedure (
                     database, schema, name, signature,
-                    last_altered, body_sha256, indexed_at
+                    last_altered, body_sha256, indexed_at, chunker_version
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(database, schema, name, signature)
                 DO UPDATE SET last_altered=excluded.last_altered,
                               body_sha256=excluded.body_sha256,
-                              indexed_at=excluded.indexed_at;
+                              indexed_at=excluded.indexed_at,
+                              chunker_version=excluded.chunker_version;
                 """,
                 (
                     key.database,
@@ -125,6 +141,7 @@ class MetadataStore:
                     last_altered,
                     body_sha256,
                     indexed_at,
+                    chunker_version,
                 ),
             )
 
@@ -215,6 +232,21 @@ class MetadataStore:
                 (key.database, key.schema, key.name, key.signature),
             ).fetchone()
         return None if row is None else str(row["body_sha256"])
+
+    def get_chunker_version(self, key: ProcedureKey) -> int | None:
+        """Return the chunker version used to index this procedure, if present."""
+
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT chunker_version FROM procedure
+                WHERE database=? AND schema=? AND name=? AND signature=?;
+                """,
+                (key.database, key.schema, key.name, key.signature),
+            ).fetchone()
+        if row is None:
+            return None
+        return int(row["chunker_version"])
 
     def get_last_altered(self, key: ProcedureKey) -> str | None:
         """Return stored last_altered for a procedure, if present."""

--- a/tests/unit/test_kb_chunker.py
+++ b/tests/unit/test_kb_chunker.py
@@ -152,3 +152,35 @@ def test_property_does_not_drop_more_than_one_percent(body: str) -> None:
     loss = abs(len(body) - len(reconstructed)) / max(1, len(body))
     assert not math.isnan(loss)
     assert loss <= 0.01
+
+
+def test_chunk_enforces_max_tokens_on_monolithic_body() -> None:
+    """A body with no logical boundaries must still be split ≤ MAX_TOKENS.
+
+    Simulates a procedure with one gigantic statement and no semicolons at top
+    level — the shape that caused the BGE-M3 truncation warning in production.
+    """
+
+    original = chunker._count_tokens
+    chunker._count_tokens = _wc_tokens
+    try:
+        # 12000 whitespace-separated words, no semicolons, no BEGIN/END — the
+        # chunker's logical splitter has nothing to latch onto, so the ceiling
+        # is the only defense.
+        body = " ".join(f"w{i}" for i in range(12000))
+        chunks = chunker.chunk(body)
+
+        assert chunks, "chunker must emit at least one chunk"
+        for ch in chunks:
+            assert _wc_tokens(ch.text) <= chunker.MAX_TOKENS, (
+                f"chunk over MAX_TOKENS={chunker.MAX_TOKENS}: got {_wc_tokens(ch.text)}"
+            )
+    finally:
+        chunker._count_tokens = original
+
+
+def test_chunker_version_is_positive_int() -> None:
+    """Sanity: CHUNKER_VERSION exists and starts at ≥ 1 (0 = pre-versioning)."""
+
+    assert isinstance(chunker.CHUNKER_VERSION, int)
+    assert chunker.CHUNKER_VERSION >= 1

--- a/tests/unit/test_kb_indexer.py
+++ b/tests/unit/test_kb_indexer.py
@@ -47,6 +47,7 @@ class _FakeMetadataStore:
         self.path: Path = path
         self.body_sha: dict[tuple[str, str, str, str], str] = {}
         self.last_alt: dict[tuple[str, str, str, str], str] = {}
+        self.chunker_ver: dict[tuple[str, str, str, str], int] = {}
         self._dbs: set[str] = set()
 
     def ensure_schema(self) -> None:
@@ -55,11 +56,21 @@ class _FakeMetadataStore:
     def get_body_sha256(self, key: ProcedureKey) -> str | None:
         return self.body_sha.get((key.database, key.schema, key.name, key.signature))
 
+    def get_chunker_version(self, key: ProcedureKey) -> int | None:
+        return self.chunker_ver.get((key.database, key.schema, key.name, key.signature))
+
     def get_last_altered(self, key: ProcedureKey) -> str | None:
         return self.last_alt.get((key.database, key.schema, key.name, key.signature))
 
-    def upsert_procedure(self, key: ProcedureKey, last_altered: str, body_sha256: str) -> None:
+    def upsert_procedure(
+        self,
+        key: ProcedureKey,
+        last_altered: str,
+        body_sha256: str,
+        chunker_version: int = 0,
+    ) -> None:
         self.body_sha[(key.database, key.schema, key.name, key.signature)] = body_sha256
+        self.chunker_ver[(key.database, key.schema, key.name, key.signature)] = chunker_version
         if last_altered:
             self.last_alt[(key.database, key.schema, key.name, key.signature)] = last_altered
         self._dbs.add(key.database)
@@ -324,6 +335,63 @@ def test_refresh_one_indexes_and_then_skips_by_body_hash(
     last_event = events[-1]
     assert last_event["skipped"] is True
     assert last_event["indexed"] is not True
+
+
+@pytest.mark.unit
+def test_refresh_one_reindexes_when_chunker_version_drifts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same DDL body + older chunker_version → re-index (not skipped).
+
+    Simulates a stored-state migration: user ran bootstrap with chunker v0
+    (pre-versioning), we bumped the chunker, next refresh must re-chunk the
+    same body even though its ``body_sha256`` matches.
+    """
+
+    fake_meta = _FakeMetadataStore(tmp_path / "metadata.sqlite")
+    fake_client = _FakeNzMcpClient(bin_path="nz-mcp")
+
+    def _meta_factory(_p: Path) -> _FakeMetadataStore:
+        return fake_meta
+
+    def _chroma_factory(root: Path) -> _FakeChromaStore:
+        return _FakeChromaStore(root)
+
+    def _client_factory(*, bin_path: str) -> _FakeNzMcpClient:
+        assert bin_path
+        return fake_client
+
+    monkeypatch.setattr(
+        indexer,
+        "load_config",
+        lambda: _Cfg(state_dir=tmp_path, nz_mcp_bin="nz-mcp", embedder_model="BAAI/bge-m3"),
+    )
+    monkeypatch.setattr(indexer, "MetadataStore", _meta_factory)
+    monkeypatch.setattr(indexer, "ChromaStore", _chroma_factory)
+    monkeypatch.setattr(indexer, "NzMcpClient", _client_factory)
+    monkeypatch.setattr(indexer, "make_embedder", lambda _name: _FakeEmbedder())
+    monkeypatch.setattr(
+        indexer,
+        "chunk",
+        lambda _ddl: [
+            type("C", (), {"text": "x", "line_from": 1, "line_to": 1, "section_hint": "body"})()
+        ],
+    )
+
+    # First pass indexes at the current chunker version.
+    r1 = indexer.refresh_one("PROD_X", "DBO", "SP1")
+    assert r1.procedures_indexed == 1
+    assert fake_client.get_ddl_calls == 1
+
+    # Simulate an older chunker having indexed this row (e.g. pre-migration).
+    key = ProcedureKey(database="PROD_X", schema="DBO", name="SP1", signature="()")
+    fake_meta.chunker_ver[(key.database, key.schema, key.name, key.signature)] = 0
+
+    # Second pass: body hash still matches but chunker_version drifted → re-index.
+    r2 = indexer.refresh_one("PROD_X", "DBO", "SP1")
+    assert r2.procedures_indexed == 1, "stale chunker_version must trigger re-index"
+    assert r2.procedures_skipped == 0
+    assert fake_client.get_ddl_calls == 2
 
 
 @pytest.mark.unit

--- a/tests/unit/test_kb_metadata_store.py
+++ b/tests/unit/test_kb_metadata_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -47,3 +48,69 @@ def test_metadata_store_roundtrip(tmp_path: Path) -> None:
 
     callers = store.procedures_calling("DBO", "SP2")
     assert callers == [key]
+
+
+@pytest.mark.unit
+def test_metadata_store_persists_chunker_version(tmp_path: Path) -> None:
+    """``get_chunker_version`` returns the value passed to ``upsert_procedure``."""
+
+    store = MetadataStore(tmp_path / "metadata.sqlite")
+    store.ensure_schema()
+
+    key = ProcedureKey(database="PROD_X", schema="DBO", name="SP_V", signature="()")
+    store.upsert_procedure(
+        key,
+        last_altered="2026-01-01T00:00:00Z",
+        body_sha256="hash-xyz",
+        chunker_version=3,
+    )
+
+    assert store.get_chunker_version(key) == 3
+
+    # Missing procedure returns None.
+    other = ProcedureKey(database="OTHER", schema="X", name="Y", signature="()")
+    assert store.get_chunker_version(other) is None
+
+
+@pytest.mark.unit
+def test_metadata_store_migrates_legacy_db_without_chunker_version(tmp_path: Path) -> None:
+    """Older DBs (pre-versioning) must get the column added on ``ensure_schema``."""
+
+    path = tmp_path / "legacy.sqlite"
+    # Build a legacy schema: procedure table without chunker_version.
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE procedure (
+                database       TEXT NOT NULL,
+                schema         TEXT NOT NULL,
+                name           TEXT NOT NULL,
+                signature      TEXT NOT NULL,
+                last_altered   TEXT,
+                body_sha256    TEXT,
+                indexed_at     TEXT NOT NULL,
+                PRIMARY KEY (database, schema, name, signature)
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO procedure VALUES (?, ?, ?, ?, ?, ?, ?);",
+            (
+                "PROD_X",
+                "DBO",
+                "OLD_SP",
+                "()",
+                "2020-01-01T00:00:00Z",
+                "oldhash",
+                "2020-01-02T00:00:00Z",
+            ),
+        )
+
+    store = MetadataStore(path)
+    store.ensure_schema()
+
+    key = ProcedureKey(database="PROD_X", schema="DBO", name="OLD_SP", signature="()")
+    # Column exists and defaults to 0 (pre-versioning marker).
+    assert store.get_chunker_version(key) == 0
+    # Existing row wasn't clobbered.
+    assert store.get_body_sha256(key) == "oldhash"


### PR DESCRIPTION
## ¿Qué cambia?

Garantiza que todos los chunks del indexer pesan ≤ **2000 tokens** via un ceiling post-stitch (``_enforce_chunk_ceiling``). Antes, procs con bloques monolíticos (muy típicos en SPs de Netezza de 50k+ líneas) podían generar chunks > 8192 tokens que BGE-M3 truncaba silenciosamente — la cola nunca entraba al embedding y quedaba invisible al retrieval semántico.

Introduce ``CHUNKER_VERSION`` persistido en ``procedure.chunker_version`` con migración automática (``ALTER TABLE ADD COLUMN`` si no existe). El indexer invalida el skip por ``body_sha256`` cuando la versión almacenada ≠ actual: bump del chunker dispara re-index sin requerir flag manual.

## Issue relacionado

Closes #11

## Acción según AGENTS.md

- **Ruta (keywords)**: chunker, embeddings, BGE-M3 truncation, reindex
- **Docs leídos**: ``AGENTS.md``, ``docs/standards/testing.md``, ``CHANGELOG.md``
- **Rol asumido**: Backend (autor IA) + Tech Lead

## Auditoría pre-merge

- [x] 1. Contract and compatibility — CHANGELOG bilingüe en ``Fixed`` + ``Added``. Migración SQLite aditiva (``DEFAULT 0``); DBs existentes siguen funcionando y se re-indexan solas.
- [x] 2. Security — sin SQL directo a Netezza, sin credenciales; solo chunking local.
- [x] 3. Maintainability — ``_enforce_chunk_ceiling`` y ``_hard_split_text`` ambos < 50 LoC; una intención por PR; versioning es un ``Final[int]`` + columna.
- [x] 4. Tests — nuevo caso sintético valida ``MAX_TOKENS`` en cuerpo de 12k palabras; roundtrip + migración de ``chunker_version``; ``refresh_one`` re-indexa cuando versión drifta aunque hash coincida. Suite 82/82 verde, coverage 85.70%.
- [x] 5. Typing and style — ``ruff`` + ``mypy --strict`` limpios.
- [x] 6. Documentation — docstrings en las funciones nuevas + comentario en la constante ``MAX_TOKENS`` explicando por qué 2000 y no 8192.
- [x] 7. Language and form — título conventional en español, branch ``fix/11-...``, commit en español, código/comentarios en inglés.
- [x] Zero-guess — el ceiling de 2000 tokens está explícito y justificado (headroom vs BGE-M3 8192); la migración usa ``PRAGMA table_info`` en vez de asumir presencia de la columna.

## Validación humana

- [x] Sí — explicar por qué: **continuación de la excepción al patrón dual-IA** acordada desde #7. El usuario pidió explícitamente cerrar el loop end-to-end por Claude tras ver el warning de BGE-M3 en su bootstrap real. Validación humana = re-correr ``kb-bootstrap --databases PROD_MODELOS`` tras el merge y confirmar que el warning desaparece para procs grandes y que los ya indexados se re-procesan por el bump de versión.