### PR TITLE
fix(kb): no llama nz_analyze_procedure_references (issue 13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) y el p
 - ES: `CHUNKER_VERSION` persistido en `procedure.chunker_version` (migración automática para DBs legacy). El indexer re-chunka/re-embedda cuando la versión almacenada no coincide con la actual, aunque `body_sha256` sea el mismo. Así un bump del chunker dispara re-index sin requerir `--force` manual.
 - EN: `CHUNKER_VERSION` persisted in `procedure.chunker_version` (auto-migrates legacy DBs). The indexer re-chunks/re-embeds when the stored version doesn't match the current one, even if `body_sha256` is unchanged — a chunker bump triggers re-index without requiring manual `--force`.
 
+### Changed
+- ES: indexer deja de llamar `nz_analyze_procedure_references` (tool inexistente en nz-mcp). La extracción de referencias estructurales ahora va 100% por regex sobre el DDL. Esto elimina los ~4 WARNINGs `Tool '…' not listed, no validation will be performed` por procedure que rompían la barra Rich. Si nz-mcp expone la tool en el futuro, se re-enchufa en `_index_one`.
+- EN: the indexer no longer calls `nz_analyze_procedure_references` (tool doesn't exist in nz-mcp). Structural reference extraction is now 100% regex over the DDL. Removes the ~4 `Tool '…' not listed, no validation will be performed` WARNINGs per procedure that shredded the Rich bar. If nz-mcp exposes the tool later, wire it back in `_index_one`.
+
 ### Fixed
 - ES: `NzMcpClient.call()` ahora desenvuelve el envelope MCP de `tools/call` (lee `structuredContent.result`) y mapea errores estructurados; incluye fallback a JSON en bloques `content`.
 - EN: `NzMcpClient.call()` now unwraps the MCP `tools/call` envelope (reads `structuredContent.result`) and maps structured errors; includes fallback to JSON in `content` blocks.

--- a/src/nz_workbench/kb/indexer.py
+++ b/src/nz_workbench/kb/indexer.py
@@ -22,7 +22,6 @@ _log = structlog.get_logger(__name__)
 
 _TOOL_LIST_PROCS: Final[str] = "nz_list_procedures"
 _TOOL_GET_DDL: Final[str] = "nz_get_procedure_ddl"
-_TOOL_ANALYZE_REFS: Final[str] = "nz_analyze_procedure_references"
 _TOOL_LIST_SCHEMAS: Final[str] = "nz_list_schemas"
 _QUAL_DB_SCHEMA_OBJ: Final[int] = 3
 _QUAL_SCHEMA_OBJ: Final[int] = 2
@@ -366,35 +365,6 @@ def _fallback_regex_references(ddl: str) -> list[Reference]:
     return refs
 
 
-def _extract_references(res: ToolResult) -> list[Reference]:
-    if not _tool_ok(res) or res.result is None:
-        return []
-    raw = res.result.get("references") or res.result.get("refs")
-    if not isinstance(raw, list):
-        return []
-    refs: list[Reference] = []
-    for item in raw:
-        if not isinstance(item, dict):
-            continue
-        kind = item.get("kind")
-        if kind not in {"read", "write", "call"}:
-            continue
-        refs.append(
-            Reference(
-                kind=kind,
-                op=str(item.get("op") or ""),
-                ref_database=item.get("ref_database"),
-                ref_schema=item.get("ref_schema"),
-                ref_object=str(item.get("ref_object") or ""),
-                line_from=int(item["line_from"])
-                if isinstance(item.get("line_from"), int)
-                else None,
-                line_to=int(item["line_to"]) if isinstance(item.get("line_to"), int) else None,
-            )
-        )
-    return refs
-
-
 def _index_one(
     *,
     client: NzMcpClient,
@@ -466,19 +436,10 @@ def _index_one(
 
     chroma.upsert(ids=ids, vectors=vectors, metadatas=metadatas, documents=documents)
 
-    ref_res = _call_with_fallbacks(
-        client,
-        _TOOL_ANALYZE_REFS,
-        [
-            {"database": proc.database, "schema": proc.schema, "procedure": proc.name},
-            {"database": proc.database, "schema": proc.schema, "name": proc.name},
-            {"ddl": ddl},
-            {"body": ddl},
-        ],
-    )
-    references = _extract_references(ref_res)
-    if not references:
-        references = _fallback_regex_references(ddl)
+    # nz-mcp doesn't expose a reference-analysis tool today; regex extraction
+    # over the DDL covers the structural queries we need (writers, callers).
+    # If a semantic analyzer lands in nz-mcp later, re-introduce the call here.
+    references = _fallback_regex_references(ddl)
 
     metadata.upsert_procedure(
         key,

--- a/src/nz_workbench/kb/metadata_store.py
+++ b/src/nz_workbench/kb/metadata_store.py
@@ -1,6 +1,6 @@
 """SQLite store for structural procedure metadata (reads / writes / calls).
 
-Populated by the indexer using ``nz_analyze_procedure_references`` from nz-mcp.
+Populated by the indexer via regex extraction over the procedure DDL.
 Consumed by structural queries (e.g. "which SPs write to table X?").
 """
 

--- a/tests/unit/test_kb_indexer_helpers.py
+++ b/tests/unit/test_kb_indexer_helpers.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from nz_workbench.kb.indexer import _extract_references, _fallback_regex_references
-from nz_workbench.nz_mcp_client import ToolResult
+from nz_workbench.kb.indexer import _fallback_regex_references
 
 
 @pytest.mark.unit
@@ -21,29 +20,3 @@ def test_fallback_regex_references_finds_reads_writes_calls() -> None:
     refs = _fallback_regex_references(ddl)
     kinds = {r.kind for r in refs}
     assert {"read", "write", "call"}.issubset(kinds)
-
-
-@pytest.mark.unit
-def test_extract_references_parses_tool_payload() -> None:
-    res = ToolResult(
-        ok=True,
-        result={
-            "references": [
-                {
-                    "kind": "read",
-                    "op": "SELECT",
-                    "ref_database": None,
-                    "ref_schema": "DBO",
-                    "ref_object": "T",
-                    "line_from": 1,
-                    "line_to": 2,
-                }
-            ]
-        },
-        error_code=None,
-        error_context=None,
-    )
-    refs = _extract_references(res)
-    assert len(refs) == 1
-    assert refs[0].kind == "read"
-    assert refs[0].ref_schema == "DBO"


### PR DESCRIPTION
## ¿Qué cambia?

El indexer deja de llamar a ``nz_analyze_procedure_references``, una tool que nz-mcp **nunca expuso**. Cada bootstrap emitía ~4 WARNINGs por procedure (``Tool '…' not listed, no validation will be performed``) del SDK MCP client-side, rompiendo la animación de la barra Rich. El path único de extracción de referencias pasa a ser ``_fallback_regex_references`` sobre el DDL, que ya cubre writers/readers/callers y estaba siendo el que se usaba en la práctica cuando la tool fallaba.

Elimino ``_TOOL_ANALYZE_REFS`` y ``_extract_references`` (dead code). Actualizo docstring de ``metadata_store.py``.

## Issue relacionado

Closes #13

## Acción según AGENTS.md

- **Ruta (keywords)**: indexer, kb-bootstrap, MCP tool lookup, UX
- **Docs leídos**: ``AGENTS.md``, ``CHANGELOG.md``
- **Rol asumido**: Backend (autor IA) + Tech Lead

## Auditoría pre-merge

- [x] 1. Contract and compatibility — CHANGELOG bilingüe en ``### Changed``. Sin breaking: en producción la tool fallaba y se usaba regex igual, solo eliminamos el intento fallido.
- [x] 2. Security — no toca SQL directo; solo regex sobre DDL.
- [x] 3. Maintainability — neto -62 LoC (eliminar dead code). Una intención por PR.
- [x] 4. Tests — test de ``_extract_references`` removido junto al símbolo; ``_fallback_regex_references`` tiene test existente que sigue verde. Suite 76/76 local.
- [x] 5. Typing and style — ``ruff`` + ``mypy --strict`` limpios.
- [x] 6. Documentation — docstring de ``metadata_store.py`` actualizado para no mentir; CHANGELOG bilingüe; comentario inline explica por qué no hay llamada MCP.
- [x] 7. Language and form — título conventional en español, branch ``fix/13-...``, commit en español, código/comentarios en inglés.
- [x] Zero-guess — comentario explícito sobre el re-enchufe futuro si nz-mcp expone la tool.

## Validación humana

- [x] Sí — continuación de la excepción al patrón dual-IA acordada desde #7. Validación humana = correr ``kb-bootstrap`` tras el merge (y tras #12) y confirmar que no salen más líneas ``Tool 'nz_analyze_procedure_references' not listed``.