### PR TITLE
feat: optimize kb-bootstrap using batch DDL fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) y el p
 
 ## [Unreleased]
 
+### Changed
+- ES: `kb-bootstrap` ahora usa `nz_get_procedures_ddl_batch` para obtener los DDL de un schema en una sola query, reduciendo el número de consultas al servidor Netezza de N a 1 por schema. Fallback automático a extracción individual si la tool batch no está disponible.
+- EN: `kb-bootstrap` now uses `nz_get_procedures_ddl_batch` to fetch all schema DDLs in a single query, reducing queries to the Netezza server from N to 1 per schema. Automatically falls back to individual DDL extraction if the batch tool is unavailable.
+
 ### Added
 - ES: bootstrap inicial del proyecto — `AGENTS.md`, docs de arquitectura, standards, templates de RENs, skeleton de código, scripts CI.
 - EN: initial project bootstrap — `AGENTS.md`, architecture docs, standards, REN templates, code skeleton, CI scripts.

--- a/src/nz_workbench/kb/indexer.py
+++ b/src/nz_workbench/kb/indexer.py
@@ -22,6 +22,7 @@ _log = structlog.get_logger(__name__)
 
 _TOOL_LIST_PROCS: Final[str] = "nz_list_procedures"
 _TOOL_GET_DDL: Final[str] = "nz_get_procedure_ddl"
+_TOOL_GET_ALL_DDL: Final[str] = "nz_get_procedures_ddl_batch"
 _TOOL_LIST_SCHEMAS: Final[str] = "nz_list_schemas"
 _QUAL_DB_SCHEMA_OBJ: Final[int] = 3
 _QUAL_SCHEMA_OBJ: Final[int] = 2
@@ -139,6 +140,17 @@ def _parse_proc_list(database: str, schema: str, raw: list[dict[str, Any]]) -> l
     return procs
 
 
+def _fetch_all_procedures_ddl(client: NzMcpClient, database: str, schema: str) -> dict[str, Any] | None:
+    """Intenta batch; retorna None si la tool no existe."""
+    res = client.call(_TOOL_GET_ALL_DDL, {"database": database, "schema": schema})
+    if res.error_code in ("TOOL_NOT_FOUND", "UNKNOWN_TOOL"):
+        return None
+    if not res.ok:
+        _log.warning("kb_bootstrap_batch_ddl_failed", database=database, schema=schema, error=res.error_code)
+        return None
+    return res.result
+
+
 def _list_schema_names(client: NzMcpClient, database: str) -> tuple[list[str], str | None]:
     schemas_res = _call_with_fallbacks(
         client,
@@ -195,6 +207,7 @@ def _index_procedures(
     chroma: ChromaStore,
     metadata: MetadataStore,
     embedder: Embedder,
+    batch_ddls: dict[str, str] | None = None,
     on_progress: ProgressCallback | None = None,
 ) -> tuple[int, int, int, list[str]]:
     indexed = 0
@@ -254,12 +267,14 @@ def _index_procedures(
             schema=proc.schema,
             procedure=proc.name,
         )
+        proc_ddl = batch_ddls.get(proc.name) if batch_ddls is not None else None
         did_index, chunks, err = _index_one(
             client=client,
             chroma=chroma,
             metadata=metadata,
             embedder=embedder,
             proc=proc,
+            ddl=proc_ddl,
         )
         if err is not None:
             errors.append(err)
@@ -401,6 +416,7 @@ def _index_one(
     metadata: MetadataStore,
     embedder: Embedder,
     proc: _ProcInfo,
+    ddl: str | None = None,
 ) -> tuple[int, int, str | None]:
     key = ProcedureKey(
         database=proc.database,
@@ -409,24 +425,25 @@ def _index_one(
         signature=proc.signature,
     )
 
-    ddl_res = _call_with_fallbacks(
-        client,
-        _TOOL_GET_DDL,
-        [
-            {"database": proc.database, "schema": proc.schema, "procedure": proc.name},
-            {"database": proc.database, "schema": proc.schema, "name": proc.name},
-            {"database": proc.database, "procedure": f"{proc.schema}.{proc.name}"},
-            {"database": proc.database, "target": f"{proc.schema}.{proc.name}"},
-        ],
-    )
-    ddl = _extract_text(ddl_res, keys=("ddl", "body", "source"))
     if ddl is None:
-        detail = f"{proc.database}.{proc.schema}.{proc.name}"
-        return (
-            0,
-            0,
-            f"failed to fetch DDL for {detail}: {ddl_res.error_code}",
+        ddl_res = _call_with_fallbacks(
+            client,
+            _TOOL_GET_DDL,
+            [
+                {"database": proc.database, "schema": proc.schema, "procedure": proc.name},
+                {"database": proc.database, "schema": proc.schema, "name": proc.name},
+                {"database": proc.database, "procedure": f"{proc.schema}.{proc.name}"},
+                {"database": proc.database, "target": f"{proc.schema}.{proc.name}"},
+            ],
         )
+        ddl = _extract_text(ddl_res, keys=("ddl", "body", "source"))
+        if ddl is None:
+            detail = f"{proc.database}.{proc.schema}.{proc.name}"
+            return (
+                0,
+                0,
+                f"failed to fetch DDL for {detail}: {ddl_res.error_code}",
+            )
 
     body_hash = _sha256(ddl)
     previous_hash = metadata.get_body_sha256(key)
@@ -525,6 +542,37 @@ def bootstrap(
                     procs.sort(key=lambda p: p.size_bytes or 0, reverse=True)
                     procs = procs[:top_n]
 
+                batch_res = _fetch_all_procedures_ddl(client, db, schema_name)
+                batch_ddls: dict[str, str] | None = None
+                if batch_res is not None:
+                    batch_procs = batch_res.get("procedures")
+                    if isinstance(batch_procs, list):
+                        batch_ddls = {}
+                        updated_procs = []
+                        for p in procs:
+                            updated_p = p
+                            for item in batch_procs:
+                                if not isinstance(item, dict):
+                                    continue
+                                item_name = str(item.get("name") or "").strip()
+                                if item_name == p.name:
+                                    last_alt = str(item.get("last_altered") or "")
+                                    ddl_str = str(item.get("ddl") or "")
+                                    if ddl_str:
+                                        batch_ddls[item_name] = ddl_str
+                                    if last_alt:
+                                        updated_p = _ProcInfo(
+                                            database=p.database,
+                                            schema=p.schema,
+                                            name=p.name,
+                                            signature=p.signature,
+                                            last_altered=last_alt,
+                                            size_bytes=p.size_bytes,
+                                        )
+                                    break
+                            updated_procs.append(updated_p)
+                        procs = updated_procs
+
                 total_discovered += sum(_work_units(p) for p in procs)
                 if on_progress is not None:
                     on_progress({"stage": "total_update", "total": total_discovered})
@@ -535,6 +583,7 @@ def bootstrap(
                     chroma=chroma,
                     metadata=metadata,
                     embedder=embedder,
+                    batch_ddls=batch_ddls,
                     on_progress=on_progress,
                 )
                 procedures_indexed += newly_indexed

--- a/tests/unit/test_kb_indexer.py
+++ b/tests/unit/test_kb_indexer.py
@@ -86,6 +86,7 @@ class _FakeNzMcpClient:
     def __init__(self, bin_path: str) -> None:
         self.bin_path = bin_path
         self.get_ddl_calls = 0
+        self.get_ddl_batch_calls = 0
 
     def start(self) -> None:
         return
@@ -151,6 +152,32 @@ class _FakeNzMcpClient:
                 error_code=None,
                 error_context=None,
             )
+        if tool == "nz_get_procedures_ddl_batch":
+            self.get_ddl_batch_calls += 1
+            if arguments.get("schema") == "DBO":
+                return ToolResult(
+                    ok=True,
+                    result={
+                        "procedures": [
+                            {
+                                "name": "SP1",
+                                "ddl": "BEGIN\nSELECT 1;\nEND;\n",
+                                "last_altered": "2026-01-01T00:00:00Z",
+                                "size_bytes": 10,
+                            }
+                        ],
+                        "count": 1,
+                        "duration_ms": 10
+                    },
+                    error_code=None,
+                    error_context=None,
+                )
+            return ToolResult(
+                ok=False,
+                result=None,
+                error_code="UNKNOWN_TOOL",
+                error_context={"tool": tool, "arguments": arguments},
+            )
         return ToolResult(
             ok=False,
             result=None,
@@ -196,12 +223,12 @@ def test_bootstrap_indexes_and_skips_by_last_altered(
     r1 = indexer.bootstrap(["PROD_X"])
     assert r1.procedures_indexed == 1
     assert r1.errors == []
-    assert fake_client.get_ddl_calls == 1
+    assert fake_client.get_ddl_batch_calls == 1
 
     r2 = indexer.bootstrap(["PROD_X"])
     assert r2.procedures_indexed == 0
     assert r2.procedures_skipped == 1
-    assert fake_client.get_ddl_calls == 1  # last_altered skip avoids re-fetching DDL
+    assert fake_client.get_ddl_batch_calls == 2  # Fetched batch but skipped local indexing
 
 
 @pytest.mark.unit
@@ -385,7 +412,7 @@ def test_bootstrap_invalidates_skip_when_chunker_version_drifts(
     # First bootstrap at the current chunker version indexes normally.
     r1 = indexer.bootstrap(["PROD_X"])
     assert r1.procedures_indexed == 1
-    assert fake_client.get_ddl_calls == 1
+    assert fake_client.get_ddl_batch_calls == 1
 
     # Simulate a legacy index (chunker v0) while last_altered still matches PROD.
     key = ProcedureKey(database="PROD_X", schema="DBO", name="SP1", signature="()")
@@ -395,7 +422,7 @@ def test_bootstrap_invalidates_skip_when_chunker_version_drifts(
     r2 = indexer.bootstrap(["PROD_X"])
     assert r2.procedures_indexed == 1, "chunker_version drift must invalidate bootstrap skip"
     assert r2.procedures_skipped == 0
-    assert fake_client.get_ddl_calls == 2
+    assert fake_client.get_ddl_batch_calls == 2
 
 
 @pytest.mark.unit
@@ -505,3 +532,94 @@ def test_refresh_one_surfaces_ddl_fetch_failure(
     assert done["error"] is not None
     assert done["indexed"] is False
     assert done["skipped"] is False
+
+
+@pytest.mark.unit
+def test_bootstrap_uses_batch_ddl(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fake_meta = _FakeMetadataStore(tmp_path / "metadata.sqlite")
+    fake_client = _FakeNzMcpClient(bin_path="nz-mcp")
+
+    def _meta_factory(_p: Path) -> _FakeMetadataStore:
+        return fake_meta
+
+    def _chroma_factory(root: Path) -> _FakeChromaStore:
+        return _FakeChromaStore(root)
+
+    def _client_factory(*, bin_path: str) -> _FakeNzMcpClient:
+        return fake_client
+
+    monkeypatch.setattr(
+        indexer,
+        "load_config",
+        lambda: _Cfg(state_dir=tmp_path, nz_mcp_bin="nz-mcp", embedder_model="BAAI/bge-m3"),
+    )
+    monkeypatch.setattr(indexer, "MetadataStore", _meta_factory)
+    monkeypatch.setattr(indexer, "ChromaStore", _chroma_factory)
+    monkeypatch.setattr(indexer, "NzMcpClient", _client_factory)
+    monkeypatch.setattr(indexer, "make_embedder", lambda _name: _FakeEmbedder())
+    monkeypatch.setattr(
+        indexer,
+        "chunk",
+        lambda _ddl: [
+            type("C", (), {"text": "x", "line_from": 1, "line_to": 1, "section_hint": "body"})()
+        ],
+    )
+
+    r1 = indexer.bootstrap(["PROD_X"])
+    assert r1.procedures_indexed == 1
+    assert r1.errors == []
+    assert fake_client.get_ddl_batch_calls == 1
+    assert fake_client.get_ddl_calls == 0
+
+
+@pytest.mark.unit
+def test_bootstrap_fallback_to_individual_ddl(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fake_meta = _FakeMetadataStore(tmp_path / "metadata.sqlite")
+    fake_client = _FakeNzMcpClient(bin_path="nz-mcp")
+
+    # Force batch to fail with UNKNOWN_TOOL
+    original_call = fake_client.call
+    def fallback_call(tool: str, arguments: dict[str, Any]) -> ToolResult:
+        if tool == "nz_get_procedures_ddl_batch":
+            return ToolResult(
+                ok=False,
+                result=None,
+                error_code="UNKNOWN_TOOL",
+                error_context={"tool": tool},
+            )
+        return original_call(tool, arguments)
+
+    fake_client.call = fallback_call  # type: ignore
+
+    def _meta_factory(_p: Path) -> _FakeMetadataStore:
+        return fake_meta
+
+    def _chroma_factory(root: Path) -> _FakeChromaStore:
+        return _FakeChromaStore(root)
+
+    def _client_factory(*, bin_path: str) -> _FakeNzMcpClient:
+        return fake_client
+
+    monkeypatch.setattr(
+        indexer,
+        "load_config",
+        lambda: _Cfg(state_dir=tmp_path, nz_mcp_bin="nz-mcp", embedder_model="BAAI/bge-m3"),
+    )
+    monkeypatch.setattr(indexer, "MetadataStore", _meta_factory)
+    monkeypatch.setattr(indexer, "ChromaStore", _chroma_factory)
+    monkeypatch.setattr(indexer, "NzMcpClient", _client_factory)
+    monkeypatch.setattr(indexer, "make_embedder", lambda _name: _FakeEmbedder())
+    monkeypatch.setattr(
+        indexer,
+        "chunk",
+        lambda _ddl: [
+            type("C", (), {"text": "x", "line_from": 1, "line_to": 1, "section_hint": "body"})()
+        ],
+    )
+
+    r1 = indexer.bootstrap(["PROD_X"])
+    assert r1.procedures_indexed == 1
+    assert r1.errors == []
+    # Individual fetch is used
+    assert fake_client.get_ddl_calls == 1
+


### PR DESCRIPTION
Resolves #17 by implementing the batch DDL fetcher to optimize Netezza queries during kb-bootstrap. Fallback logic is present.